### PR TITLE
Create tag objects instead of lightweight tags

### DIFF
--- a/tbump/git_bumper.py
+++ b/tbump/git_bumper.py
@@ -79,7 +79,7 @@ class GitBumper():
             ui.info_2("Would create tag:", tag_name)
         else:
             ui.info_2("Creating tag", tag_name)
-            self.run_git("tag", tag_name)
+            self.run_git("tag", "--annotate", "--message", tag_name, tag_name)
 
     def bump(self, new_version, dry_run=False):
         message = self.message_template.format(new_version=new_version)


### PR DESCRIPTION
As per the [Git Documentation](https://git-scm.com/docs/git-tag):

>Annotated tags are meant for release while lightweight tags are meant for private or temporary object labels. For this reason, some git commands for naming objects (like git describe) will ignore lightweight tags by default.

Note that I just happily changed the behavior, but you might want to introduce an option instead.